### PR TITLE
Change openslide and imagemagick links so that they work at present

### DIFF
--- a/7.36/vips.modules
+++ b/7.36/vips.modules
@@ -84,7 +84,7 @@
   <repository 
     type="tarball" 
     name="github" 
-    href="http://github.com/downloads/"
+    href="http://github.com/"
   />
 
   <repository 
@@ -172,7 +172,7 @@
     >
     <branch
       repo="github"
-      module="openslide/openslide/openslide-3.3.3.tar.gz"
+      module="openslide/openslide/releases/download/v3.3.3/openslide-3.3.3.tar.gz"
       version="3.3.3"
     />
     <dependencies>
@@ -255,7 +255,7 @@
     >
     <branch
       repo="magick"
-      module="ImageMagick/ImageMagick-6.8.7-0.tar.gz"
+      module="ImageMagick/ImageMagick-6.8.7-10.tar.gz"
       version="6.8.7"
     />
     <dependencies>


### PR DESCRIPTION
As they are, the locations of the tarballs for openslide and imagemagick are incorrect; openslide because the location is now https://github.com/openslide/openslide/releases/download/v3.3.3/openslide-3.3.3.tar.gz and imagemagick because ImageMagick-6.8.7-0 has been superseded by ImageMagick-6.8.7-10 (and -0 has been removed from that server).  The ImageMagick thing is quite annoying, as every single time they upload a new version they remove the old one.

As a side note, it's also possible to build libvips-win32 with the latest openslide pretty easily -- the "corresponding sources" found at http://openslide.cs.cmu.edu/download/snapshots/windows/ each include a tar/openslide-3.3.3.tar.xz file (that is not, amusingly enough, openslide-3.3.3 at all; it's the latest openslide git master at the time of build) that can be used verbatim (well, by converting it into a .tar.gz).  Since handling of WSI formats like BIF has been greatly improved since 3.3.3, this is what I've been doing.
